### PR TITLE
Specify dtype in get_dummies when one-hot-encoding

### DIFF
--- a/code/preprocessing.py
+++ b/code/preprocessing.py
@@ -46,7 +46,7 @@ def encode_predictors_housing_data(X):
     # add nominal fields as dummy vars
     X_enc = X.copy()
     X_enc.loc[:, nominal_fields]=X[nominal_fields].astype("category")
-    one_hot = pd.get_dummies(X_enc[nominal_fields])
+    one_hot = pd.get_dummies(X_enc[nominal_fields], dtype=int)
     keep_cols.extend(one_hot.columns)
     X_enc=X_enc.join(one_hot)
     


### PR DESCRIPTION
[Since pandas 2.0.0](https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html#other-api-changes) the default behavior of `get_dummies` is to produce booleans.

This currently causes errors in some of our helper functions.

The proposed fix is to specify `dtype=int` when calling `get_dummies`.