### PR TITLE
Show metric name in measure_model_err output

### DIFF
--- a/code/regression_predict_sklearn.py
+++ b/code/regression_predict_sklearn.py
@@ -108,9 +108,9 @@ def measure_model_err(y: Union[np.ndarray, pd.Series], baseline_pred: Union[floa
     
     # Create a DataFrame to store the error values
     errors_df = pd.DataFrame({
-        'Baseline Error': [baseline_err],
-        'Train Error': [train_err],
-        'Test Error': [test_err]
+        f'Baseline {metric}': [baseline_err],
+        f'Train {metric}': [train_err],
+        f'Test {metric}': [test_err]
     })
 
     return errors_df


### PR DESCRIPTION
There was a point of confusion seeing a baseline method have "0 error" when viewing R-squared.

This modifies `measure_model_err` to output the name of the metric used to clarify what is being shown.